### PR TITLE
Add Azure blob document viewer

### DIFF
--- a/DocumentViewerApp/Controllers/DocumentController.cs
+++ b/DocumentViewerApp/Controllers/DocumentController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using DocumentViewerApp.Models;
+
+namespace DocumentViewerApp.Controllers
+{
+    public class DocumentController : Controller
+    {
+        private static readonly HashSet<string> AllowedExtensions = new()
+        {
+            ".pdf", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"
+        };
+
+        [HttpGet]
+        public IActionResult Index(string? url)
+        {
+            if (!string.IsNullOrWhiteSpace(url))
+            {
+                return RedirectToAction(nameof(Preview), new { url });
+            }
+            return View();
+        }
+
+        [HttpPost]
+        public IActionResult Index(DocumentViewModel model)
+        {
+            if (string.IsNullOrWhiteSpace(model.DocumentUrl))
+            {
+                ModelState.AddModelError(nameof(model.DocumentUrl), "Document URL is required");
+                return View(model);
+            }
+            if (!IsExtensionAllowed(model.DocumentUrl))
+            {
+                ModelState.AddModelError(nameof(model.DocumentUrl), "File type not supported");
+                return View(model);
+            }
+            return RedirectToAction(nameof(Preview), new { url = model.DocumentUrl });
+        }
+
+        [HttpGet]
+        public IActionResult Preview(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url) || !IsExtensionAllowed(url))
+            {
+                return BadRequest("Invalid or unsupported document url");
+            }
+
+            var model = new DocumentViewModel { DocumentUrl = url };
+            return View(model);
+        }
+
+        private static bool IsExtensionAllowed(string url)
+        {
+            try
+            {
+                var ext = Path.GetExtension(url).ToLowerInvariant();
+                return AllowedExtensions.Contains(ext);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/DocumentViewerApp/Models/DocumentViewModel.cs
+++ b/DocumentViewerApp/Models/DocumentViewModel.cs
@@ -1,0 +1,7 @@
+namespace DocumentViewerApp.Models
+{
+    public class DocumentViewModel
+    {
+        public string DocumentUrl { get; set; } = string.Empty;
+    }
+}

--- a/DocumentViewerApp/Program.cs
+++ b/DocumentViewerApp/Program.cs
@@ -29,7 +29,7 @@ namespace DocumentViewerApp
 
             app.MapControllerRoute(
                 name: "default",
-                pattern: "{controller=Home}/{action=Index}/{id?}");
+                pattern: "{controller=Document}/{action=Index}/{id?}");
 
             app.Run();
         }

--- a/DocumentViewerApp/Views/Document/Index.cshtml
+++ b/DocumentViewerApp/Views/Document/Index.cshtml
@@ -1,0 +1,16 @@
+@model DocumentViewerApp.Models.DocumentViewModel
+@{
+    ViewData["Title"] = "Document Viewer";
+}
+<h2>Document Viewer</h2>
+<form asp-action="Index" method="post">
+    <div class="mb-3">
+        <label asp-for="DocumentUrl" class="form-label">Document URL</label>
+        <input asp-for="DocumentUrl" class="form-control" />
+        <span asp-validation-for="DocumentUrl" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Preview</button>
+</form>
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/DocumentViewerApp/Views/Document/Preview.cshtml
+++ b/DocumentViewerApp/Views/Document/Preview.cshtml
@@ -1,0 +1,13 @@
+@model DocumentViewerApp.Models.DocumentViewModel
+@{
+    ViewData["Title"] = "Preview";
+    var extension = System.IO.Path.GetExtension(Model.DocumentUrl).ToLowerInvariant();
+}
+@if (extension == ".pdf")
+{
+    <iframe src="@Model.DocumentUrl" width="100%" height="600px"></iframe>
+}
+else
+{
+    <img src="@Model.DocumentUrl" class="img-fluid" alt="Preview" />
+}

--- a/DocumentViewerApp/Views/Home/Index.cshtml
+++ b/DocumentViewerApp/Views/Home/Index.cshtml
@@ -4,5 +4,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>
+        <a class="btn btn-primary" asp-controller="Document" asp-action="Index">Open Document Viewer</a>
+    </p>
 </div>

--- a/DocumentViewerApp/Views/Shared/_Layout.cshtml
+++ b/DocumentViewerApp/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Document" asp-action="Index">Document Viewer</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>


### PR DESCRIPTION
## Summary
- add `DocumentController` with URL validation
- set default route to `Document` controller
- add `DocumentViewModel` to pass the blob URL
- create viewer pages for input and preview
- update layout and home page links

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841898b57dc832996a130adecad1f3d